### PR TITLE
chore: Increase Dependabot cooldown to 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,11 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 2
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 2
+      default-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,4 +61,4 @@ jobs:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
 
-      - run: npm publish *.tgz
+      - run: npm publish ./*.tgz


### PR DESCRIPTION
Given the recent supply chain attacks, this raises Dependabot's minimum package age to seven days before version update PRs are opened.

Existing stricter cooldowns stay in place, so major and minor updates that already waited longer continue to do so.